### PR TITLE
Take `current_time` parameter

### DIFF
--- a/tests/test_overall.py
+++ b/tests/test_overall.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import reduce
 import random
 import time
@@ -18,7 +19,8 @@ def test_basic():
 
 
 def test_uuid64_fields():
-    uuid = uuid64.issue()
+    current_time = datetime.utcnow()
+    uuid = uuid64.issue(current_time=current_time)
     timestamp, node_id = uuid64.uuid64_fields(uuid)
-    assert 0 <= timestamp < (1 << 48)
+    assert abs(current_time.timestamp() - timestamp) < 0.01
     assert 0 <= node_id <= 0xFFFF

--- a/uuid64.py
+++ b/uuid64.py
@@ -27,10 +27,10 @@ def uuid64_fields(uuid64):
     """
     :type uuid64: int
     """
-    return (uuid64 >> 48, uuid64 & 0xFFFF)
+    return ((uuid64 >> 16) / 10000, uuid64 & 0xFFFF)
 
 
-class UUID64(object):
+class UUID64:
     def __init__(self, node_id):
         self.node_id = node_id
 
@@ -42,7 +42,7 @@ class UUID64(object):
         return int(time_seq << 16 | (self.node_id & 0xFFFF))
 
 
-def issue(node_id=None):
+def issue(current_time=None, node_id=None):
     if node_id is None:
         try:
             host = socket.gethostbyname(socket.gethostname())
@@ -51,4 +51,4 @@ def issue(node_id=None):
         local_ip = os.environ.get("IPV4_ADDR", host)
         node_id = ipv4_to_int(local_ip) % (2 ** 16)
     uuid = UUID64(node_id)
-    return uuid.issue()
+    return uuid.issue(current_time)

--- a/uuid64.py
+++ b/uuid64.py
@@ -34,8 +34,10 @@ class UUID64(object):
     def __init__(self, node_id):
         self.node_id = node_id
 
-    def issue(self):
-        time_seq = int(time.time() * 10000)
+    def issue(self, current_time: datetime = None):
+        if current_time is None:
+            current_time = datetime.utcnow()
+        time_seq = int(current_time.timestamp() * 10000)
 
         return int(time_seq << 16 | (self.node_id & 0xFFFF))
 


### PR DESCRIPTION
* Makes the code more test-friendly
* Fixed a bug where the decomposition of the time field was incorrect